### PR TITLE
fix: use multi-argument URI constructor for correct IPv6 formatting

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/GlobalConfig.scala
+++ b/src/main/scala/timshel/s3dedupproxy/GlobalConfig.scala
@@ -23,7 +23,7 @@ case class Proxy(
     port: Port,
     purge: CronExpression
 ) derives ConfigReader {
-  val uri = URI.create(s"http://${host}:${port}")
+  val uri = new URI("http", null, host.toString, port.value, null, null, null)
 }
 
 case class DBConfig(


### PR DESCRIPTION
String interpolation of an IPv6 address like ::1 produces http://::1:8080, which java.net.URI cannot parse (getHost returns null, getPort returns -1). This causes S3Proxy to bind to all interfaces on a random port instead of the configured address.

The multi-argument URI constructor automatically brackets IPv6 addresses per RFC 2732, producing http://\[::1\]:8080.