### PR TITLE
fix: add grace period to getDangling to prevent race with uploads

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/Database.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Database.scala
@@ -241,6 +241,7 @@ case class Database(
         FROM file_metadata
           LEFT JOIN file_mappings ON file_mappings.hash = file_metadata.hash
         WHERE file_mappings.uuid IS NULL
+          AND file_metadata.created < NOW() - INTERVAL '1 hour'
         ORDER BY file_metadata.created ASC
         LIMIT $int4
     """


### PR DESCRIPTION
The cleanup purge could delete metadata and S3 objects for in-progress uploads. Uploads create file_metadata and file_mappings in separate steps, so a metadata row briefly exists without a mapping. If purge's getDangling query runs in that window, it treats the hash as dangling and deletes it, causing data loss.

Add a 1-hour grace period so only metadata older than 1 hour with no mappings is considered dangling. This is far longer than any upload could take, eliminating the race window.