### PR TITLE
fix: prevent TOCTOU race in cleanup purge with atomic re-check

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/Cleanup.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Cleanup.scala
@@ -30,7 +30,7 @@ case class Cleanup(
     for {
       hashes <- db.getDangling(1000)
       _      <- client.deleteKeys(hashes)
-      count  <- db.delMetadatas(hashes)
+      count  <- db.delDanglingMetadatas(hashes)
       _ = log.debug(s"Purged $count files")
     } yield count
   }

--- a/src/main/scala/timshel/s3dedupproxy/Database.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Database.scala
@@ -235,6 +235,31 @@ case class Database(
     } else IO.pure(0)
   }
 
+  /** Atomically deletes metadata rows only if they still have no mappings.
+    * Prevents TOCTOU race where a concurrent upload creates a mapping
+    * between getDangling and the delete.
+    */
+  def delDanglingMetadatasC(count: Int): Command[(List[HashCode])] = {
+    sql"""
+      DELETE FROM file_metadata
+        WHERE hash IN (${hashE.list(count)})
+          AND NOT EXISTS (SELECT 1 FROM file_mappings WHERE file_mappings.hash = file_metadata.hash)
+    """.command
+  }
+
+  def delDanglingMetadatas(hashes: List[HashCode]): IO[Int] = {
+    if (hashes.nonEmpty) {
+      pool.use {
+        _.prepare(delDanglingMetadatasC(hashes.size))
+          .flatMap { pc => pc.execute(hashes) }
+          .map {
+            case Completion.Delete(count) => count
+            case _                        => throw new AssertionError("delDanglingMetadatas execution should only return Delete")
+          }
+      }
+    } else IO.pure(0)
+  }
+
   val getDanglingQ: Query[Int, HashCode] =
     sql"""
       SELECT file_metadata.hash


### PR DESCRIPTION
purge() had a race condition: getDangling finds orphaned hashes, then deleteKeys removes S3 objects (slow), then delMetadatas removes DB rows. If a concurrent upload inserts a mapping for the same hash during the deleteKeys window, delMetadatas would CASCADE-delete that new mapping, making the just-uploaded file inaccessible.

Replace delMetadatas with delDanglingMetadatas which atomically checks NOT EXISTS(mappings) in the DELETE statement. If a mapping was created between getDangling and the delete, the metadata row is preserved and the CASCADE cannot destroy the new mapping.

The original delMetadatas is kept for other callers that need unconditional deletion.