### PR TITLE
fix: decode URL-encoded path before DB lookup in redirect controller

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/Controllers.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Controllers.scala
@@ -16,7 +16,8 @@ case class RedirectionController(
   }
 
   val routes = org.http4s.HttpRoutes.of[IO] { case _ @GET -> StringVar(identity) /: StringVar(bucket) /: key =>
-    db.getMappingHash(identity, bucket, key.toString).flatMap {
+    val decodedKey = java.net.URLDecoder.decode(key.toString, "UTF-8")
+    db.getMappingHash(identity, bucket, decodedKey).flatMap {
       case None => IO.pure(Response[IO](Status.NotFound))
       case Some(hash) =>
         val path = ProxyBlobStore.hashToKey(hash)


### PR DESCRIPTION
http4s Uri.Path.toString returns the URL-encoded form of the path (e.g. file%20name.txt), but the database stores decoded keys since S3Proxy decodes path segments before calling into the blob store.

This mismatch caused 404s for any file with spaces or special characters in its name. Decode the key before the DB lookup to match the stored value.