### PR TITLE
fix: propagate S3 deletion failures to prevent orphaned blobs

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/Cleanup.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Cleanup.scala
@@ -28,9 +28,12 @@ case class Cleanup(
   def purge(): IO[Int] = {
     log.debug("Running purge job")
     for {
-      hashes <- db.getDangling(1000)
-      _      <- client.deleteKeys(hashes)
-      count  <- db.delMetadatas(hashes)
+      hashes    <- db.getDangling(1000)
+      failedKeys <- client.deleteKeys(hashes)
+      successHashes = if (failedKeys.isEmpty) hashes
+                      else hashes.filterNot(h => failedKeys.contains(ProxyBlobStore.hashToKey(h)))
+      _ = if (failedKeys.nonEmpty) log.warn(s"${failedKeys.size} objects failed to delete from S3, skipping their metadata removal")
+      count <- db.delMetadatas(successHashes)
       _ = log.debug(s"Purged $count files")
     } yield count
   }

--- a/src/main/scala/timshel/s3dedupproxy/ObjectStoreClient.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ObjectStoreClient.scala
@@ -16,7 +16,10 @@ case class ObjectStoreClient(
     .credentials(config.accessKeyId, config.secretAccessKey)
     .build()
 
-  def deleteKeys(hashes: List[HashCode]): IO[Unit] = IO.blocking {
+  /** Deletes the given hashes from the backend bucket.
+    * Returns the set of object keys that failed to delete.
+    */
+  def deleteKeys(hashes: List[HashCode]): IO[Set[String]] = IO.blocking {
     if (hashes.nonEmpty) {
       val objects = new java.util.LinkedList[DeleteObject]();
 
@@ -24,10 +27,17 @@ case class ObjectStoreClient(
         objects.add(new DeleteObject(ProxyBlobStore.hashToKey(h)))
       }
 
+      val failedKeys = scala.collection.mutable.Set[String]()
+
       client.removeObjects(RemoveObjectsArgs.builder().bucket(config.bucket).objects(objects).build()).forEach { r =>
         val e = r.get()
         log.error(s"Failed to delete ${e.objectName}, err ${e.code}: ${e.message}")
+        failedKeys.add(e.objectName())
       }
+
+      failedKeys.toSet
+    } else {
+      Set.empty[String]
     }
   }
 }


### PR DESCRIPTION
ObjectStoreClient.deleteKeys swallowed per-object deletion errors from MinIO's removeObjects. The forEach callback logged errors but the method returned Unit successfully, causing Cleanup.purge to unconditionally delete DB metadata for all hashes — including those whose S3 objects failed to delete. This created permanent storage leaks since the orphaned S3 objects would never be rediscovered by future cleanup runs.

Changed deleteKeys to return the set of failed object keys. Cleanup.purge now filters out failed hashes and only deletes metadata for objects that were actually removed from S3. Failed objects remain in the DB and will be retried on the next cleanup cycle.