### PR TITLE
fix: restore Content-Type after setPayload in putBlob

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -274,6 +274,7 @@ class ProxyBlobStore(
         val his     = new com.google.common.hash.HashingInputStream(Hashing.sha512(), counter)
         val md5     = new com.google.common.hash.HashingInputStream(ProxyBlobStore.MD5, his)
         blob.setPayload(md5)
+        blob.getMetadata().getContentMetadata().setContentType(contenType)
         bufferStore.putBlob(container, blob)
         (counter.getCount(), his.hash(), md5.hash())
       }


### PR DESCRIPTION
blob.setPayload(InputStream) replaces the payload with a new InputStreamPayload that has default content metadata, losing the original Content-Type. Re-apply the captured contenType onto the blob's content metadata before writing to the bufferStore.