### PR TITLE
fix: default to application/octet-stream when Content-Type is null

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -264,7 +264,7 @@ class ProxyBlobStore(
   override def putBlob(container: String, blob: Blob): String = {
     log.debug(s"putBlob($container, $blob)")
     val name       = blob.getMetadata().getName()
-    val contenType = blob.getMetadata().getContentMetadata().getContentType()
+    val contenType = Option(blob.getMetadata().getContentMetadata().getContentType()).getOrElse("application/octet-stream")
 
     val p = (for {
       _ <- ensureContainerExists(container)
@@ -381,7 +381,7 @@ class ProxyBlobStore(
 
     val container  = mpu.containerName()
     val name       = mpu.blobName()
-    val contenType = mpu.blobMetadata().getContentMetadata().getContentType()
+    val contenType = Option(mpu.blobMetadata().getContentMetadata().getContentType()).getOrElse("application/octet-stream")
 
     val p = (for {
       completed <- IO.blocking(bufferStore.completeMultipartUpload(mpu, parts))


### PR DESCRIPTION
Clients may omit Content-Type, causing getContentType() to return null. Since the DB schema requires content_type to be NOT NULL, this causes db.putMetadata to fail with a constraint violation, aborting the upload.

Default to application/octet-stream in both putBlob and completeMultipartUpload when the client does not provide a Content-Type.