### PR TITLE
fix: restore Content-Type on buffered blob before backend upload

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -306,6 +306,7 @@ class ProxyBlobStore(
               val metadata = blob.getMetadata()
               metadata.setContainer(bucket)
               metadata.setName(ProxyBlobStore.hashToKey(hash))
+              metadata.getContentMetadata().setContentType(contenType)
               delegate().putBlob(
                 bucket,
                 blob,


### PR DESCRIPTION
The filesystem bufferStore does not persist blob metadata. When processBufferDedup reads the blob back and uploads it to the backend, the Content-Type is lost. Explicitly set the captured contenType on the blob's content metadata before the delegate putBlob call.