### PR TITLE
fix: set Location header on PermanentRedirect response

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/Controllers.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Controllers.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 
 import org.http4s._
 import org.http4s.dsl.io._
+import org.http4s.headers.Location
 
 case class RedirectionController(
     config: BackendConfig,
@@ -19,8 +20,9 @@ case class RedirectionController(
     db.getMappingHash(identity, bucket, key.toString).flatMap {
       case None => IO.pure(Response[IO](Status.NotFound))
       case Some(hash) =>
-        val path = ProxyBlobStore.hashToKey(hash)
-        PermanentRedirect(config.publicHost + "/" + path)
+        val path      = ProxyBlobStore.hashToKey(hash)
+        val targetUri = Uri.unsafeFromString(config.publicHost + "/" + path)
+        PermanentRedirect(Location(targetUri))
     }
   }
 }


### PR DESCRIPTION
PermanentRedirect(String) in http4s treats the string as the response body, not as a Location header. Clients following redirects rely on the Location header, so the redirect was effectively broken for all clients.

Use PermanentRedirect(Location(Uri)) to properly set the header.