### PR TITLE
refactor: use IO.blocking for getBlob delegate calls

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -158,18 +158,18 @@ class ProxyBlobStore(
 
   override def getBlob(container: String, name: String): Blob = {
     log.debug(s"getBlob($container, $name)")
-    val p = getMapKey(container, name).map {
-      case Some(key) => delegate().getBlob(bucket, key)
-      case None      => null
+    val p = getMapKey(container, name).flatMap {
+      case Some(key) => IO.blocking(delegate().getBlob(bucket, key))
+      case None      => IO.pure(null)
     }
     dispatcher.unsafeRunSync(p)
   }
 
   override def getBlob(container: String, name: String, getOptions: GetOptions): Blob = {
     log.debug(s"getBlob($container, $name, $getOptions)")
-    val p = getMapKey(container, name).map {
-      case Some(key) => delegate().getBlob(bucket, key, getOptions)
-      case None      => null
+    val p = getMapKey(container, name).flatMap {
+      case Some(key) => IO.blocking(delegate().getBlob(bucket, key, getOptions))
+      case None      => IO.pure(null)
     }
     dispatcher.unsafeRunSync(p)
   }


### PR DESCRIPTION
getBlob was calling delegate().getBlob() inside IO.map, which runs on the Cats Effect compute pool. These are blocking network calls to the S3 backend that can starve compute threads under load. Changed to IO.blocking to match the pattern used by downloadBlob, streamBlob, and blobMetadata.