### PR TITLE
refactor: verify metadata exists before creating mapping in copyBlob

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -339,11 +339,11 @@ class ProxyBlobStore(
         case Some(hash) => hash
         case None       => throw new IllegalArgumentException("Not found")
       }
-      _ <- db.putMapping(identity, toContainer, toName, hash)
       metadata <- db.getMetadata(hash).map {
         case Some(metadata) => metadata
         case None           => throw new IllegalArgumentException("Not found")
       }
+      _ <- db.putMapping(identity, toContainer, toName, hash)
     } yield metadata.eTag
 
     dispatcher.unsafeRunSync(p)


### PR DESCRIPTION
copyBlob was calling putMapping before getMetadata. If getMetadata returned None, the user got an error despite the mapping already being created. Reordered to verify first, mutate second.