### PR TITLE
refactor: fix TOCTOU race in ensureContainerExists

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -256,10 +256,8 @@ class ProxyBlobStore(
   }
 
   private def ensureContainerExists(container: String): IO[Unit] = IO.blocking {
-    if (!bufferStore.containerExists(container)) {
-      bufferStore.createContainerInLocation(null, container)
-    }
-  }
+    bufferStore.createContainerInLocation(null, container)
+  }.void
 
   override def putBlob(container: String, blob: Blob): String = {
     log.debug(s"putBlob($container, $blob)")


### PR DESCRIPTION
The check-then-create pattern (containerExists + createContainerInLocation) had a race where two concurrent uploads could both see false and both try to create. createContainerInLocation is idempotent (returns false for existing containers), so just call it directly.