### PR TITLE
refactor: cache ProxyBlobStore instances per identity

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -104,13 +104,16 @@ object ProxyBlobStore {
 
     val blobStore = createBlobStore(config.backend)
 
-    s3Proxy.setBlobStoreLocator((identity, container, blob) => {
-      val proxyBlobStore =
-        ProxyBlobStore(createBufferStore(identity), blobStore, identity, config.backend.bucket, db, dispatcher)
+    val proxyCache = new java.util.concurrent.ConcurrentHashMap[String, ProxyBlobStore]()
 
+    s3Proxy.setBlobStoreLocator((identity, container, blob) => {
       config.users.get(identity) match {
-        case Some(secret) => Maps.immutableEntry(secret, proxyBlobStore);
-        case None         => throw new SecurityException("Access denied")
+        case Some(secret) =>
+          val proxyBlobStore = proxyCache.computeIfAbsent(identity, _ =>
+            ProxyBlobStore(createBufferStore(identity), blobStore, identity, config.backend.bucket, db, dispatcher)
+          )
+          Maps.immutableEntry(secret, proxyBlobStore);
+        case None => throw new SecurityException("Access denied")
       }
     });
 


### PR DESCRIPTION
setBlobStoreLocator was creating a new ProxyBlobStore (and a new jclouds filesystem BlobStore context) for every S3 API call. This is expensive — each creation builds a Guice injector and thread pools.

Cache instances per identity using ConcurrentHashMap.computeIfAbsent. ProxyBlobStore is stateless (all state is in the DB), so sharing instances across requests is safe.