### PR TITLE
refactor: add index on file_metadata.created for cleanup perf

### DIFF
--- a/src/main/resources/db/migration/V02__add_metadata_created_index.sql
+++ b/src/main/resources/db/migration/V02__add_metadata_created_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX file_metadata_created ON file_metadata(created ASC);


### PR DESCRIPTION
getDangling filters by created < NOW() - INTERVAL '1 hour' and orders by created ASC. Without an index, this requires a sequential scan of the entire file_metadata table on every cleanup run.