### PR TITLE
refactor/safety: verify backend blob exists on dedup fast path

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -297,25 +297,32 @@ class ProxyBlobStore(
       size: Long,
       contenType: String
   ): IO[String] = {
+    def uploadFromBuffer: IO[String] = for {
+      eTag <- IO.blocking {
+        val blob     = bufferStore.getBlob(container, name)
+        val metadata = blob.getMetadata()
+        metadata.setContainer(bucket)
+        metadata.setName(ProxyBlobStore.hashToKey(hash))
+        metadata.getContentMetadata().setContentType(contenType)
+        delegate().putBlob(
+          bucket,
+          blob,
+          new PutOptions().setBlobAccess(BlobAccess.PUBLIC_READ).multipart(size > 5 * 1024 * 1024)
+        );
+      }
+      _ <- db.putMetadata(hash, md5, size, eTag, contenType)
+    } yield eTag
+
     db.getMetadata(hash)
       .flatMap {
-        case Some(metadata) => IO.pure(metadata.eTag)
-        case None =>
-          for {
-            eTag <- IO.blocking {
-              val blob     = bufferStore.getBlob(container, name)
-              val metadata = blob.getMetadata()
-              metadata.setContainer(bucket)
-              metadata.setName(ProxyBlobStore.hashToKey(hash))
-              metadata.getContentMetadata().setContentType(contenType)
-              delegate().putBlob(
-                bucket,
-                blob,
-                new PutOptions().setBlobAccess(BlobAccess.PUBLIC_READ).multipart(size > 5 * 1024 * 1024)
-              );
-            }
-            _ <- db.putMetadata(hash, md5, size, eTag, contenType)
-          } yield eTag
+        case Some(metadata) =>
+          IO.blocking(delegate().blobExists(bucket, ProxyBlobStore.hashToKey(hash))).flatMap {
+            case true  => IO.pure(metadata.eTag)
+            case false =>
+              log.warn(s"Backend blob missing for hash $hash, re-uploading from buffer")
+              uploadFromBuffer
+          }
+        case None => uploadFromBuffer
       }
       .flatMap { eTag =>
         for {


### PR DESCRIPTION
When processBufferDedup finds existing metadata (dedup hit), it now verifies the backend S3 object actually exists before skipping the upload. If the blob is missing (e.g., deleted by cleanup race or manual intervention), it re-uploads from the buffer instead of creating a mapping to a non-existent object.

Extracted uploadFromBuffer helper to avoid code duplication between the dedup-miss and dedup-hit-but-missing-blob paths.