### PR TITLE
fix: close input stream on error in putBlob hashing pipeline

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -270,13 +270,19 @@ class ProxyBlobStore(
       _ <- ensureContainerExists(container)
       (size, hash, md5) <- IO.blocking {
         val is      = blob.getPayload().openStream();
-        val counter = new com.google.common.io.CountingInputStream(is);
-        val his     = new com.google.common.hash.HashingInputStream(Hashing.sha512(), counter)
-        val md5     = new com.google.common.hash.HashingInputStream(ProxyBlobStore.MD5, his)
-        blob.setPayload(md5)
-        blob.getMetadata().getContentMetadata().setContentType(contenType)
-        bufferStore.putBlob(container, blob)
-        (counter.getCount(), his.hash(), md5.hash())
+        try {
+          val counter = new com.google.common.io.CountingInputStream(is);
+          val his     = new com.google.common.hash.HashingInputStream(Hashing.sha512(), counter)
+          val md5     = new com.google.common.hash.HashingInputStream(ProxyBlobStore.MD5, his)
+          blob.setPayload(md5)
+          blob.getMetadata().getContentMetadata().setContentType(contenType)
+          bufferStore.putBlob(container, blob)
+          (counter.getCount(), his.hash(), md5.hash())
+        } catch {
+          case e: Throwable =>
+            is.close()
+            throw e
+        }
       }
       eTag <- processBufferDedup(container, name, hash, md5, size, contenType)
     } yield eTag)


### PR DESCRIPTION
If bufferStore.putBlob or the hashing stream wrappers throw, the original input stream from blob.getPayload().openStream() was never closed, leaking the file descriptor. Added try/catch to close the stream on error. On success, the stream is consumed and closed by the bufferStore write.