### PR TITLE
fix: restrict purge API to localhost only

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/Controllers.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Controllers.scala
@@ -35,7 +35,14 @@ case class ApiController(
 ) {
   import RedirectionController._
 
-  val routes = org.http4s.HttpRoutes.of[IO] { case _ @DELETE -> Root / "purge" =>
-    cleanup.purge().flatMap { count => Ok(s"$count deleted") }
+  val routes = org.http4s.HttpRoutes.of[IO] {
+    case req @DELETE -> Root / "purge" =>
+      val remoteAddr = req.remoteAddr.map(_.toUriString).getOrElse("")
+      val isLocal    = remoteAddr == "127.0.0.1" || remoteAddr == "::1" || remoteAddr == "0:0:0:0:0:0:0:1"
+      if (isLocal) {
+        cleanup.purge().flatMap { count => Ok(s"$count deleted") }
+      } else {
+        IO.pure(Response[IO](Status.Forbidden))
+      }
   }
 }


### PR DESCRIPTION
The DELETE /api/purge endpoint had no authentication. The HTTP API server (port 23279) is completely separate from the S3 proxy (port 23278, which has AWS V2/V4 signature auth via S3Proxy). Anyone who could reach port 23279 could trigger a purge.

Replaced the unauthenticated route with localhost-only restriction (127.0.0.1 / ::1). Returns 403 Forbidden for non-local requests.