### PR TITLE
refactor: add advisory lock to prevent concurrent dedup race

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/Database.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Database.scala
@@ -40,6 +40,23 @@ case class Database(
 )(implicit runtime: IORuntime) {
   import Database.*
 
+  private val advisoryLockQ: Query[Long, Void] =
+    sql"SELECT pg_advisory_xact_lock($int8)".query(skunk.Void.codec)
+
+  /** Acquires a transaction-scoped advisory lock keyed on the hash,
+    * executes the body, then commits. The lock auto-releases when
+    * the transaction ends. Uses the first 8 bytes of the hash as
+    * the lock key for good distribution.
+    */
+  def withAdvisoryLock[A](hash: HashCode)(body: IO[A]): IO[A] = {
+    val lockKey = java.nio.ByteBuffer.wrap(hash.asBytes().take(8)).getLong()
+    pool.use { session =>
+      session.transaction.use { _ =>
+        session.prepare(advisoryLockQ).flatMap(_.unique(lockKey)) >> body
+      }
+    }
+  }
+
   val mappingHashQ: Query[String *: String *: String *: EmptyTuple, HashCode] =
     sql"""
       SELECT hash FROM file_mappings

--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -297,32 +297,33 @@ class ProxyBlobStore(
       size: Long,
       contenType: String
   ): IO[String] = {
-    db.getMetadata(hash)
-      .flatMap {
-        case Some(metadata) => IO.pure(metadata.eTag)
-        case None =>
-          for {
-            eTag <- IO.blocking {
-              val blob     = bufferStore.getBlob(container, name)
-              val metadata = blob.getMetadata()
-              metadata.setContainer(bucket)
-              metadata.setName(ProxyBlobStore.hashToKey(hash))
-              metadata.getContentMetadata().setContentType(contenType)
-              delegate().putBlob(
-                bucket,
-                blob,
-                new PutOptions().setBlobAccess(BlobAccess.PUBLIC_READ).multipart(size > 5 * 1024 * 1024)
-              );
-            }
-            _ <- db.putMetadata(hash, md5, size, eTag, contenType)
-          } yield eTag
-      }
-      .flatMap { eTag =>
-        for {
-          _ <- db.putMapping(identity, container, name, hash)
-          _ <- IO.blocking(bufferStore.removeBlob(container, name))
-        } yield eTag
-      }
+    db.withAdvisoryLock(hash) {
+      db.getMetadata(hash)
+        .flatMap {
+          case Some(metadata) => IO.pure(metadata.eTag)
+          case None =>
+            for {
+              eTag <- IO.blocking {
+                val blob     = bufferStore.getBlob(container, name)
+                val metadata = blob.getMetadata()
+                metadata.setContainer(bucket)
+                metadata.setName(ProxyBlobStore.hashToKey(hash))
+                metadata.getContentMetadata().setContentType(contenType)
+                delegate().putBlob(
+                  bucket,
+                  blob,
+                  new PutOptions().setBlobAccess(BlobAccess.PUBLIC_READ).multipart(size > 5 * 1024 * 1024)
+                );
+              }
+              _ <- db.putMetadata(hash, md5, size, eTag, contenType)
+            } yield eTag
+        }
+    }.flatMap { eTag =>
+      for {
+        _ <- db.putMapping(identity, container, name, hash)
+        _ <- IO.blocking(bufferStore.removeBlob(container, name))
+      } yield eTag
+    }
   }
 
   /** javadoc says options are ignored, so we ignore them too


### PR DESCRIPTION
Two concurrent uploads of identical content could both check getMetadata(hash), both get None, both upload to the backend, and both call putMetadata. The second UPSERT overwrites the first's eTag, leaving the first caller with a stale eTag.

Added withAdvisoryLock(hash) using pg_advisory_xact_lock to serialize the getMetadata → upload → putMetadata section per hash. The lock key is derived from the first 8 bytes of the SHA-512 hash. Transaction-scoped locks auto-release on commit or rollback, preventing deadlocks from crashes.

The putMapping and buffer cleanup remain outside the lock since they don't need serialization.