### PR TITLE
refactor: validate identity against configured users in redirect endpoint

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/Application.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Application.scala
@@ -57,7 +57,7 @@ object Application extends IOApp {
       cleanup    <- Cleanup.scheduled(config, database, dispatcher)
       httpApp = org.http4s.server
         .Router(
-          "/proxy/" -> RedirectionController(config.backend, database).routes,
+          "/proxy/" -> RedirectionController(config.backend, database, config.users.keySet).routes,
           "/api/"   -> ApiController(cleanup).routes
         )
         .orNotFound

--- a/src/main/scala/timshel/s3dedupproxy/Controllers.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Controllers.scala
@@ -8,7 +8,8 @@ import org.http4s.headers.Location
 
 case class RedirectionController(
     config: BackendConfig,
-    db: Database
+    db: Database,
+    validUsers: Set[String]
 ) {
   import RedirectionController._
 
@@ -17,11 +18,15 @@ case class RedirectionController(
   }
 
   val routes = org.http4s.HttpRoutes.of[IO] { case _ @GET -> StringVar(identity) /: StringVar(bucket) /: key =>
-    db.getMappingHash(identity, bucket, key.toString).flatMap {
-      case None => IO.pure(Response[IO](Status.NotFound))
-      case Some(hash) =>
-        val path = ProxyBlobStore.hashToKey(hash)
-        PermanentRedirect(Location(config.publicHost.addSegment(path)))
+    if (!validUsers.contains(identity)) {
+      IO.pure(Response[IO](Status.Forbidden))
+    } else {
+      db.getMappingHash(identity, bucket, key.toString).flatMap {
+        case None => IO.pure(Response[IO](Status.NotFound))
+        case Some(hash) =>
+          val path = ProxyBlobStore.hashToKey(hash)
+          PermanentRedirect(Location(config.publicHost.addSegment(path)))
+      }
     }
   }
 }


### PR DESCRIPTION
The redirect controller accepted any identity string and queried the DB without checking if it's a valid configured user. This allowed file enumeration by guessing identity strings. Now validates against the configured user set and returns 403 for unknown identities.