### PR TITLE
Major Refactor: upgrade s3proxy from 2.6.0 submodule to 3.1.0 Maven dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "s3proxy"]
-	path = s3proxy
-	url = https://github.com/gaul/s3proxy.git

--- a/build.sbt
+++ b/build.sbt
@@ -18,25 +18,14 @@ lazy val root = project
     ),
     javaOptions += "-Duser.timezone=UTC",
     Compile / mainClass := Some("timshel.s3dedupproxy.Application"),
-    unmanagedSources / excludeFilter := HiddenFileFilter
-      || "EncryptedBlobStore.java"
-      || "S3ProxyExtension.java"
-      || "S3ProxyRule.java"
-      || "Main.java",
     libraryDependencies ++= Seq(
-      // Deps from S3Proxy
-      "com.azure"                        % "azure-identity"             % "1.15.0",
-      "com.azure"                        % "azure-storage-blob"         % "12.29.0",
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml"     % "2.18.2",
-      "com.google.auto.service"          % "auto-service"               % "1.1.1",
-      "com.google.code.findbugs"         % "annotations"                % "3.0.1",
-      "com.google.code.findbugs"         % "jsr305"                     % "3.0.2",
-      "com.google.jimfs"                 % "jimfs"                      % "1.3.0",
-      "org.apache.commons"               % "commons-fileupload2-javax"  % "2.0.0-M2",
+      // S3Proxy (provides S3-compatible API layer, jclouds, Jetty transitively)
+      "org.gaul"                         % "s3proxy"                    % "3.1.0",
+
+      // Additional jclouds providers not pulled transitively
       "org.apache.jclouds"               % "jclouds-allblobstore"       % "2.7.0",
       "org.apache.jclouds.api"           % "filesystem"                 % "2.7.0",
       "org.apache.jclouds.driver"        % "jclouds-slf4j"              % "2.7.0",
-      "org.eclipse.jetty"                % "jetty-servlet"              % "11.0.24",
 
       // Leftovers
       "com.squareup.okhttp3"             % "okhttp"                     % "4.11.0",

--- a/src/main/java/org
+++ b/src/main/java/org
@@ -1,1 +1,0 @@
-../../../s3proxy/src/main/java/org


### PR DESCRIPTION
Replaced the s3proxy git submodule (pinned to 2.6.0) with the published Maven artifact (3.1.0). This is a much cleaner approach.