### PR TITLE
feat: dynamic user management via hot-reloadable users.conf

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,3 @@
 !src
 !.gitmodules
 !build.sbt
-!docker.application.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get update \
         openjdk-17-jre
 
 COPY --from=build /s3-dedup-proxy/target/universal/stage /s3-dedup-proxy
-COPY docker.application.conf /s3-dedup-proxy/application.conf
 
 WORKDIR /s3-dedup-proxy
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    volumes:
+      - ./docker.users.conf:/s3-dedup-proxy/users.conf
+      - ./docker.application.conf:/s3-dedup-proxy/application.conf
     depends_on:
       - Postgres
       - S3Proxy

--- a/docker.application.conf
+++ b/docker.application.conf
@@ -24,9 +24,6 @@
         pass: "s3proxy"
         database: "s3proxy"
     }
-    users: {
-        tenant1: "ff54fae017ebe20356223ea016d1e2e867b7f73aaba775fe48ed65d1f1fecb87"
-        tenant2: "25ca6d3f04906bfc05a3f2c7ce6b5569ec841ee0ef241a886f34687bbafee7cc"
-    }
+    users-file: "docker.users.conf"
 }
 

--- a/docker.users.conf
+++ b/docker.users.conf
@@ -1,0 +1,4 @@
+{
+    tenant1: "ff54fae017ebe20356223ea016d1e2e867b7f73aaba775fe48ed65d1f1fecb87"
+    tenant2: "25ca6d3f04906bfc05a3f2c7ce6b5569ec841ee0ef241a886f34687bbafee7cc"
+}

--- a/src/main/scala/timshel/s3dedupproxy/Application.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Application.scala
@@ -10,6 +10,7 @@ import scala.concurrent.ExecutionContext
 import skunk._
 import skunk.codec.all._
 import skunk.implicits._
+import java.nio.file.Path
 
 case class Application(
     config: GlobalConfig,
@@ -53,8 +54,16 @@ object Application extends IOApp {
       )
       database = Database(pool)(runtime)
       dispatcher <- Dispatcher.parallel[IO]
-      proxy      <- ProxyBlobStore.createProxy(config, database, dispatcher)
-      cleanup    <- Cleanup.scheduled(config, database, dispatcher)
+      userRegistry <- config.usersFile match {
+        case Some(path) => UserRegistry.fromFile(Path.of(path))
+        case None =>
+          // Fallback: use static users from config (backward compatible)
+          Resource.pure[IO, UserRegistry](
+            new UserRegistry(new java.util.concurrent.atomic.AtomicReference(config.users))
+          )
+      }
+      proxy   <- ProxyBlobStore.createProxy(config, database, dispatcher, userRegistry)
+      cleanup <- Cleanup.scheduled(config, database, dispatcher)
       httpApp = org.http4s.server
         .Router(
           "/proxy/" -> RedirectionController(config.backend, database).routes,

--- a/src/main/scala/timshel/s3dedupproxy/GlobalConfig.scala
+++ b/src/main/scala/timshel/s3dedupproxy/GlobalConfig.scala
@@ -54,5 +54,6 @@ case class GlobalConfig(
     backend: BackendConfig,
     backupBackend: Option[BackendConfig] = None,
     db: DBConfig,
-    users: Map[String, String]
+    users: Map[String, String] = Map.empty,
+    usersFile: Option[String] = None
 ) derives ConfigReader

--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -92,7 +92,7 @@ object ProxyBlobStore {
 
   /** S3Proxy will throw if it sees an X-Amz header it doesn't recognize
     */
-  def createProxy(config: GlobalConfig, db: Database, dispatcher: Dispatcher[IO]): Resource[IO, S3Proxy] = {
+  def createProxy(config: GlobalConfig, db: Database, dispatcher: Dispatcher[IO], userRegistry: UserRegistry): Resource[IO, S3Proxy] = {
     val s3Proxy = S3Proxy
       .builder()
       .awsAuthentication(org.gaul.s3proxy.AuthenticationType.AWS_V2_OR_V4, "DUMMY", "DUMMY")
@@ -108,7 +108,7 @@ object ProxyBlobStore {
       val proxyBlobStore =
         ProxyBlobStore(createBufferStore(identity), blobStore, identity, config.backend.bucket, db, dispatcher)
 
-      config.users.get(identity) match {
+      userRegistry.get(identity) match {
         case Some(secret) => Maps.immutableEntry(secret, proxyBlobStore);
         case None         => throw new SecurityException("Access denied")
       }
@@ -116,8 +116,8 @@ object ProxyBlobStore {
 
     Resource.make {
       IO.blocking {
-        config.users.keys.foreach { identity => bufferStorePath(identity).mkdirs() }
-        log.debug(s"Buffer store path created for users (${config.users.keys})")
+        userRegistry.getAll.keys.foreach { identity => bufferStorePath(identity).mkdirs() }
+        log.debug(s"Buffer store path created for users (${userRegistry.getAll.keys})")
 
         s3Proxy.start()
         log.info(s"Object proxy running on ${config.proxy.uri}")

--- a/src/main/scala/timshel/s3dedupproxy/UserRegistry.scala
+++ b/src/main/scala/timshel/s3dedupproxy/UserRegistry.scala
@@ -1,0 +1,108 @@
+package timshel.s3dedupproxy
+
+import cats.effect._
+import java.nio.file.{FileSystems, Files, Path, StandardWatchEventKinds, WatchEvent}
+import java.util.concurrent.atomic.AtomicReference
+import scala.jdk.CollectionConverters._
+
+/** Thread-safe, hot-reloadable user registry backed by a HOCON file.
+  *
+  * The file format is simple key-value pairs:
+  * {{{
+  * {
+  *   tenant1: "secret-key-hex"
+  *   tenant2: "secret-key-hex"
+  * }
+  * }}}
+  *
+  * The registry watches the file for changes and reloads automatically.
+  * Reads are lock-free via AtomicReference (safe for Jetty's S3Proxy threads).
+  */
+object UserRegistry {
+  val log = com.typesafe.scalalogging.Logger(classOf[Application])
+
+  def parseUsersFile(path: Path): Map[String, String] = {
+    val config = com.typesafe.config.ConfigFactory.parseFile(path.toFile)
+    config
+      .entrySet()
+      .asScala
+      .map(e => e.getKey -> e.getValue.unwrapped().toString)
+      .toMap
+  }
+
+  /** Creates a UserRegistry Resource that watches the file and reloads on changes.
+    * The Resource ensures the watcher thread is stopped on shutdown.
+    */
+  def fromFile(path: Path): Resource[IO, UserRegistry] = {
+    Resource.make {
+      IO.blocking {
+        val absPath  = path.toAbsolutePath
+        val users    = parseUsersFile(absPath)
+        val registry = new UserRegistry(new AtomicReference(users))
+
+        log.info(s"Loaded ${users.size} users from $absPath: ${users.keys.mkString(", ")}")
+
+        // Start file watcher in a daemon thread
+        val watchDir = absPath.getParent
+        val fileName = absPath.getFileName
+        val watcher  = FileSystems.getDefault.newWatchService()
+        watchDir.register(watcher, StandardWatchEventKinds.ENTRY_MODIFY)
+
+        val watchThread = new Thread(() => {
+          try {
+            while (!Thread.currentThread().isInterrupted) {
+              val key = watcher.take()
+              val events = key.pollEvents().asScala
+              val relevant = events.exists { evt =>
+                evt.asInstanceOf[WatchEvent[Path]].context() == fileName
+              }
+              if (relevant) {
+                // Small delay to let the file finish writing
+                Thread.sleep(200)
+                try {
+                  val newUsers = parseUsersFile(absPath)
+                  val old      = registry.users.getAndSet(newUsers)
+                  val added    = newUsers.keySet -- old.keySet
+                  val removed  = old.keySet -- newUsers.keySet
+                  if (added.nonEmpty) log.info(s"Users added: ${added.mkString(", ")}")
+                  if (removed.nonEmpty) log.info(s"Users removed: ${removed.mkString(", ")}")
+                  if (added.isEmpty && removed.isEmpty) log.debug("Users file reloaded, no changes")
+                } catch {
+                  case e: Exception => log.error(s"Failed to reload users file: ${e.getMessage}")
+                }
+              }
+              key.reset()
+            }
+          } catch {
+            case _: InterruptedException => // shutdown
+          }
+        }, "user-registry-watcher")
+        watchThread.setDaemon(true)
+        watchThread.start()
+
+        (registry, watchThread, watcher)
+      }
+    } { case (_, thread, watcher) =>
+      IO.blocking {
+        log.info("Stopping user registry file watcher")
+        thread.interrupt()
+        watcher.close()
+      }
+    }.map(_._1)
+  }
+}
+
+class UserRegistry(val users: AtomicReference[Map[String, String]]) {
+
+  /** Look up a user's secret. Thread-safe, lock-free. */
+  def get(identity: String): Option[String] =
+    users.get().get(identity)
+
+  /** Get all current users. */
+  def getAll: Map[String, String] =
+    users.get()
+
+  /** Check if an identity is a valid user. */
+  def contains(identity: String): Boolean =
+    users.get().contains(identity)
+}

--- a/users.conf.example
+++ b/users.conf.example
@@ -1,0 +1,12 @@
+# S3 Dedup Proxy - User Configuration
+#
+# Format: identity: "secret-key"
+# This file is monitored for changes — add or remove users without restarting.
+#
+# To use this file, set in your application.conf:
+#   users-file: "users.conf"
+#
+{
+    tenant1: "ff54fae017ebe20356223ea016d1e2e867b7f73aaba775fe48ed65d1f1fecb87"
+    tenant2: "25ca6d3f04906bfc05a3f2c7ce6b5569ec841ee0ef241a886f34687bbafee7cc"
+}


### PR DESCRIPTION
Users can now be managed in a separate users.conf file that is monitored for changes. Adding or removing users takes effect immediately without restarting the proxy.

Usage:In application.conf replace the users JSON array with a reference to a users-file `users-file: "users.conf"`

