### PR TITLE
Proxy redirect URLs encode blob path slashes as %2F

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/Controllers.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Controllers.scala
@@ -21,7 +21,7 @@ case class RedirectionController(
       case None => IO.pure(Response[IO](Status.NotFound))
       case Some(hash) =>
         val path = ProxyBlobStore.hashToKey(hash)
-        PermanentRedirect(Location(config.publicHost.addSegment(path)))
+        PermanentRedirect(Location(config.publicHost.addPath(path)))
     }
   }
 }


### PR DESCRIPTION
I need to confirm this.