### PR TITLE
fix: update parseAndMerge

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/UserRegistry.scala
+++ b/src/main/scala/timshel/s3dedupproxy/UserRegistry.scala
@@ -33,12 +33,14 @@ case class Watcher(users: TrieMap[String, String], conf: HashSet[String], var ca
           case None => ()
           case Some(wk) =>
             log.debug(s"Polling returned $wk")
-            wk.pollEvents().asScala.exists { evt =>
+            val isUsersFileEvent = wk.pollEvents().asScala.exists { evt =>
               evt.asInstanceOf[WatchEvent[Path]].context() == fileName
             }
-            // Small delay to let the file finish writing
-            Thread.sleep(200)
-            parseAndMerge(users, conf, path)
+            if (isUsersFileEvent) {
+              // Small delay to let the file finish writing
+              Thread.sleep(200)
+              parseAndMerge(users, conf, path)
+            }
             wk.reset()
         }
       }


### PR DESCRIPTION
Use the exists() result to gate the parse/merge so only events for the watched users file trigger a reload.