### PR TITLE
fix: move putMapping inside advisory lock to prevent race with cleanup + close clients.

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/Cleanup.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Cleanup.scala
@@ -75,7 +75,8 @@ object Cleanup {
   })(cleanup =>
     IO.blocking {
       log.info("Stopping cleanup scheduler")
-      cleanup.sched.shutdown(true);
+      cleanup.sched.shutdown(true)
+      cleanup.client.close()
     }
   )
 

--- a/src/main/scala/timshel/s3dedupproxy/Database.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Database.scala
@@ -145,6 +145,14 @@ case class Database(
     }
   }
 
+  def putMapping(user_name: String, bucket: String, file_key: String, hash: HashCode)(session: Session[IO]): IO[Completion] = {
+    session
+      .prepare(putMappingC)
+      .flatMap { pc =>
+        pc.execute(user_name, bucket, file_key, hash, hash)
+      }
+  }
+
   def delMappingsC(count: Int): Command[List[(String, String, String)]] = {
     val enc = (text *: text *: text).values.list(count)
     sql"""

--- a/src/main/scala/timshel/s3dedupproxy/ObjectStoreClient.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ObjectStoreClient.scala
@@ -16,6 +16,8 @@ final case class ObjectStoreClient(
     .credentials(config.accessKeyId, config.secretAccessKey)
     .build()
 
+  def close(): Unit = client.close()
+
   def deleteKeys(hashes: List[HashCode]): IO[(List[HashCode], List[HashCode])] = IO.blocking {
     import scala.jdk.CollectionConverters.IterableHasAsScala
 

--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -340,7 +340,10 @@ class ProxyBlobStore(
   ): IO[String] = {
     db.withAdvisoryLock(hash) { s =>
       db.checkMetadata(hash)(s).flatMap {
-        case Some(metadata) => IO.pure(metadata.eTag)
+        case Some(metadata) =>
+          for {
+            _ <- db.putMapping(identity, container, name, hash)(s)
+          } yield metadata.eTag
         case None =>
           for {
             eTag <- IO.blocking {
@@ -356,11 +359,11 @@ class ProxyBlobStore(
               );
             }
             _ <- db.putMetadata(hash, md5, size, eTag, contenType)(s)
+            _ <- db.putMapping(identity, container, name, hash)(s)
           } yield eTag
       }
     }.flatMap { eTag =>
       for {
-        _ <- db.putMapping(identity, container, name, hash)
         _ <- IO.blocking(bufferStore.removeBlob(container, name))
       } yield eTag
     }


### PR DESCRIPTION
Now putMapping runs inside the lock for both the checkMetadata hit path (dedup) and the miss path (new upload), ensuring the mapping is always committed.

+ sneaky possible leak fix