### PR TITLE
Finding 4: make putMapping session-scoped and remove buffer cleanup race

### DIFF
--- a/src/main/scala/timshel/s3dedupproxy/Database.scala
+++ b/src/main/scala/timshel/s3dedupproxy/Database.scala
@@ -144,6 +144,13 @@ case class Database(
         }
     }
   }
+  def putMapping(user_name: String, bucket: String, file_key: String, hash: HashCode)(session: Session[IO]): IO[Completion] = {
+    session.prepare(putMappingC)
+      .flatMap { pc =>
+        pc.execute(user_name, bucket, file_key, hash, hash)
+      }
+  }
+
 
   def delMappingsC(count: Int): Command[List[(String, String, String)]] = {
     val enc = (text *: text *: text).values.list(count)

--- a/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
+++ b/src/main/scala/timshel/s3dedupproxy/ProxyBlobStore.scala
@@ -357,12 +357,11 @@ class ProxyBlobStore(
             }
             _ <- db.putMetadata(hash, md5, size, eTag, contenType)(s)
           } yield eTag
+      }.flatMap { eTag =>
+        db.putMapping(identity, container, name, hash)(s).map(_ => eTag)
       }
     }.flatMap { eTag =>
-      for {
-        _ <- db.putMapping(identity, container, name, hash)
-        _ <- IO.blocking(bufferStore.removeBlob(container, name))
-      } yield eTag
+      IO.blocking(bufferStore.removeBlob(container, name)).map(_ => eTag)
     }
   }
 


### PR DESCRIPTION
Notice: This is another version of the #58 with the additional report data. This was taken from the AWS code review report.

<img width="602" height="700" alt="image" src="https://github.com/user-attachments/assets/ddbb01b9-7827-4afa-8c22-0e28a02feaa4" />

<img width="602" height="700" alt="image" src="https://github.com/user-attachments/assets/b86822af-29fa-4752-8b05-a580aaffc4e8" />
